### PR TITLE
Add a GCC CI and fix GCC and Clang versions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,7 +41,7 @@ jobs:
             packages: gcc-14
           - name: Linux (Clang)
             os: ubuntu-latest
-            extra-flags: -DCMAKE_C_COMPILER=clang-14 -DCMAKE_CXX_COMPILER=clang++-14 -G"Ninja Multi-Config" -DCMAKE_C_FLAGS="-fsanitize=address -fsanitize=undefined"  -DCMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=undefined"
+            extra-flags: -DCMAKE_C_COMPILER=clang-19 -DCMAKE_CXX_COMPILER=clang++-19 -G"Ninja Multi-Config" -DCMAKE_C_FLAGS="-fsanitize=address -fsanitize=undefined"  -DCMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=undefined"
             packages: clang-19 libclang-rt-19-dev
           - name: macOS
             os: macos-15


### PR DESCRIPTION
We really want both GCC and Clang to catch as many errors as possible.
Also if one day we want to have SpatGRIS shipped as part of Linux distros
using GCC will be mandatory.

