### PR TITLE
Save standalone speakerview settings to project file

### DIFF
--- a/Data/sg_LogicStrucs.cpp
+++ b/Data/sg_LogicStrucs.cpp
@@ -92,7 +92,8 @@ juce::String const ProjectData::XmlTags::GAIN_INTERPOLATION = "GAIN_INTERPOLATIO
 juce::String const ProjectData::XmlTags::OSC_PORT = "OSC_PORT";
 juce::String const ProjectData::XmlTags::STANDALONE_SPEAKERVIEW_INPUT_PORT = "STANDALONE_SPEAKERVIEW_INPUT_PORT";
 juce::String const ProjectData::XmlTags::STANDALONE_SPEAKERVIEW_OUTPUT_PORT = "STANDALONE_SPEAKERVIEW_OUTPUT_PORT";
-juce::String const ProjectData::XmlTags::STANDALONE_SPEAKERVIEW_OUTPUT_ADDRESS = "STANDALONE_SPEAKERVIEW_OUTPUT_ADDRESS";
+juce::String const ProjectData::XmlTags::STANDALONE_SPEAKERVIEW_OUTPUT_ADDRESS
+    = "STANDALONE_SPEAKERVIEW_OUTPUT_ADDRESS";
 
 juce::String const AppData::XmlTags::MAIN_TAG = "SPAT_GRIS_APP_DATA";
 juce::String const AppData::XmlTags::LAST_SPEAKER_SETUP = "LAST_SPEAKER_SETUP";
@@ -814,7 +815,8 @@ tl::optional<ProjectData> ProjectData::fromXml(juce::XmlElement const & xml)
         result.standaloneSpeakerViewOutputPort = xml.getIntAttribute(XmlTags::STANDALONE_SPEAKERVIEW_OUTPUT_PORT);
     }
     if (xml.hasAttribute(XmlTags::STANDALONE_SPEAKERVIEW_OUTPUT_ADDRESS)) {
-        result.standaloneSpeakerViewOutputAddress = xml.getStringAttribute(XmlTags::STANDALONE_SPEAKERVIEW_OUTPUT_ADDRESS);
+        result.standaloneSpeakerViewOutputAddress
+            = xml.getStringAttribute(XmlTags::STANDALONE_SPEAKERVIEW_OUTPUT_ADDRESS);
     }
 
     for (auto const * sourceElement : sourcesElement->getChildIterator()) {

--- a/Data/sg_LogicStrucs.cpp
+++ b/Data/sg_LogicStrucs.cpp
@@ -90,6 +90,9 @@ juce::String const ProjectData::XmlTags::SOURCES = "SOURCES";
 juce::String const ProjectData::XmlTags::MASTER_GAIN = "MASTER_GAIN";
 juce::String const ProjectData::XmlTags::GAIN_INTERPOLATION = "GAIN_INTERPOLATION";
 juce::String const ProjectData::XmlTags::OSC_PORT = "OSC_PORT";
+juce::String const ProjectData::XmlTags::STANDALONE_SPEAKERVIEW_INPUT_PORT = "STANDALONE_SPEAKERVIEW_INPUT_PORT";
+juce::String const ProjectData::XmlTags::STANDALONE_SPEAKERVIEW_OUTPUT_PORT = "STANDALONE_SPEAKERVIEW_OUTPUT_PORT";
+juce::String const ProjectData::XmlTags::STANDALONE_SPEAKERVIEW_OUTPUT_ADDRESS = "STANDALONE_SPEAKERVIEW_OUTPUT_ADDRESS";
 
 juce::String const AppData::XmlTags::MAIN_TAG = "SPAT_GRIS_APP_DATA";
 juce::String const AppData::XmlTags::LAST_SPEAKER_SETUP = "LAST_SPEAKER_SETUP";
@@ -743,6 +746,12 @@ std::unique_ptr<juce::XmlElement> ProjectData::toXml() const
     result->addChildElement(mbapDistanceAttenuationData.toXml().release());
 
     result->setAttribute(XmlTags::OSC_PORT, oscPort);
+    if (standaloneSpeakerViewInputPort)
+        result->setAttribute(XmlTags::STANDALONE_SPEAKERVIEW_INPUT_PORT, *standaloneSpeakerViewInputPort);
+    if (standaloneSpeakerViewOutputPort)
+        result->setAttribute(XmlTags::STANDALONE_SPEAKERVIEW_OUTPUT_PORT, *standaloneSpeakerViewOutputPort);
+    if (standaloneSpeakerViewOutputAddress)
+        result->setAttribute(XmlTags::STANDALONE_SPEAKERVIEW_OUTPUT_ADDRESS, *standaloneSpeakerViewOutputAddress);
     result->setAttribute(XmlTags::MASTER_GAIN, masterGain.get());
     result->setAttribute(XmlTags::GAIN_INTERPOLATION, spatGainsInterpolation);
     result->setAttribute(XmlTags::VERSION, SPAT_GRIS_VERSION.toString());
@@ -797,6 +806,16 @@ tl::optional<ProjectData> ProjectData::fromXml(juce::XmlElement const & xml)
     result.oscPort = xml.getIntAttribute(XmlTags::OSC_PORT); // TODO : validate value
     result.mbapDistanceAttenuationData = *mbapAttenuation;
     result.spatMode = *spatMode;
+
+    if (xml.hasAttribute(XmlTags::STANDALONE_SPEAKERVIEW_INPUT_PORT)) {
+        result.standaloneSpeakerViewInputPort = xml.getIntAttribute(XmlTags::STANDALONE_SPEAKERVIEW_INPUT_PORT);
+    }
+    if (xml.hasAttribute(XmlTags::STANDALONE_SPEAKERVIEW_OUTPUT_PORT)) {
+        result.standaloneSpeakerViewOutputPort = xml.getIntAttribute(XmlTags::STANDALONE_SPEAKERVIEW_OUTPUT_PORT);
+    }
+    if (xml.hasAttribute(XmlTags::STANDALONE_SPEAKERVIEW_OUTPUT_ADDRESS)) {
+        result.standaloneSpeakerViewOutputAddress = xml.getStringAttribute(XmlTags::STANDALONE_SPEAKERVIEW_OUTPUT_ADDRESS);
+    }
 
     for (auto const * sourceElement : sourcesElement->getChildIterator()) {
         jassert(sourceElement);

--- a/Data/sg_LogicStrucs.hpp
+++ b/Data/sg_LogicStrucs.hpp
@@ -60,8 +60,8 @@
 
 namespace gris
 {
-constexpr auto DEFAULT_UDP_INPUT_PORT = 18022;
-constexpr auto DEFAULT_UDP_OUTPUT_PORT = 18023;
+constexpr auto DEFAULT_UDP_OUTPUT_PORT = 18022;
+constexpr auto DEFAULT_UDP_INPUT_PORT = 18023;
 
 constexpr auto DEFAULT_OSC_INPUT_PORT = 18032;
 constexpr auto MAX_OSC_INPUT_PORT = 65535;

--- a/Data/sg_LogicStrucs.hpp
+++ b/Data/sg_LogicStrucs.hpp
@@ -440,6 +440,9 @@ struct ProjectData {
     SourcesOrdering ordering{};
     MbapDistanceAttenuationData mbapDistanceAttenuationData{};
     int oscPort{ DEFAULT_OSC_INPUT_PORT };
+    tl::optional<int> standaloneSpeakerViewInputPort;
+    tl::optional<int> standaloneSpeakerViewOutputPort;
+    tl::optional<juce::String> standaloneSpeakerViewOutputAddress;
     dbfs_t masterGain{};
     float spatGainsInterpolation{};
     SpatMode spatMode{};
@@ -457,6 +460,9 @@ struct ProjectData {
         static juce::String const MASTER_GAIN;
         static juce::String const GAIN_INTERPOLATION;
         static juce::String const OSC_PORT;
+        static juce::String const STANDALONE_SPEAKERVIEW_INPUT_PORT;
+        static juce::String const STANDALONE_SPEAKERVIEW_OUTPUT_PORT;
+        static juce::String const STANDALONE_SPEAKERVIEW_OUTPUT_ADDRESS;
     };
 };
 


### PR DESCRIPTION
This saves the standalone SpeakerView networking settings to the project file.

It also fixes a terminology inversion with udp ports.