### PR TITLE
Add rtsan annotations to audio critical path

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -48,7 +48,7 @@ jobs:
             packages: clang-19 libclang-rt-19-dev clang-tools-19
           - name: Linux (Clang-20 rtsan)
             os: ubuntu-latest
-            extra-flags: -DCMAKE_C_COMPILER=clang-20 -DCMAKE_CXX_COMPILER=clang++-20 -G"Ninja Multi-Config" -DCMAKE_C_FLAGS="-fsanitize=realtime"  -DCMAKE_CXX_FLAGS="-fsanitize=realtime"
+            extra-flags: -G"Ninja Multi-Config" -DCMAKE_C_FLAGS="-fsanitize=realtime"  -DCMAKE_CXX_FLAGS="-fsanitize=realtime"
             image: ghcr.io/guillaumeriousat/algogris-rtsan:latest
           - name: macOS
             os: macos-15

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,7 +49,7 @@ jobs:
           - name: Linux (Clang-20 rtsan)
             os: ubuntu-latest
             extra-flags: -G"Ninja Multi-Config" -DCMAKE_C_FLAGS="-fsanitize=realtime"  -DCMAKE_CXX_FLAGS="-fsanitize=realtime"
-            image: ghcr.io/guillaumeriousat/algogris-rtsan:latest
+            image: realtimesanitizer/rtsan-clang
           - name: macOS
             os: macos-15
             extra-flags: -G"Ninja Multi-Config" -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"  -DCMAKE_C_FLAGS=" -fsanitize=address -fsanitize=undefined" -DCMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=undefined"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,7 +49,7 @@ jobs:
           - name: Linux (Clang-20 rtsan)
             os: ubuntu-latest
             extra-flags: -G"Ninja Multi-Config" -DCMAKE_C_FLAGS="-fsanitize=realtime"  -DCMAKE_CXX_FLAGS="-fsanitize=realtime"
-            image: realtimesanitizer/rtsan-clang
+            image: ghcr.io/guillaumeriousat/algogris-rtsan:latest
           - name: macOS
             os: macos-15
             extra-flags: -G"Ninja Multi-Config" -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"  -DCMAKE_C_FLAGS=" -fsanitize=address -fsanitize=undefined" -DCMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=undefined"
@@ -60,21 +60,16 @@ jobs:
       # Setup MSVC toolchain and developer command prompt (Windows)
       - uses: ilammy/msvc-dev-cmd@v1
 
-      - name: Get sudo (for rtsan)
-        if: runner.os == 'Linux (Clang-20 rtsan)'
-        run: |
-
-
       - name: Install JUCE's Linux Deps
         if: runner.os == 'Linux'
         # Thanks to McMartin & co https://forum.juce.com/t/list-of-juce-dependencies-under-linux/15121/44
         run: |
-          apt-get update -yqq
-          apt install -yqq libasound2-dev libx11-dev libxinerama-dev libxext-dev libfreetype6-dev libwebkit2gtk-4.1-dev libglu1-mesa-dev xvfb ninja-build libcurl4-openssl-dev ${{ matrix.packages }}
+          sudo apt-get update -yqq
+          sudo apt install -yqq libasound2-dev libx11-dev libxinerama-dev libxext-dev libfreetype6-dev libwebkit2gtk-4.1-dev libglu1-mesa-dev xvfb ninja-build libcurl4-openssl-dev ${{ matrix.packages }}
 
           # Install clang-tools for benchmark runner if missing (clang-scan-deps lives here)
           if [[ "${{ matrix.name }}" == "Linux (Benchmarks)" ]]; then
-            apt-get install -yqq clang-tools-18
+            sudo apt-get install -yqq clang-tools-18
           fi
 
       - name: Install Ninja (Windows)

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -60,16 +60,21 @@ jobs:
       # Setup MSVC toolchain and developer command prompt (Windows)
       - uses: ilammy/msvc-dev-cmd@v1
 
+      - name: Get sudo (for rtsan)
+        if: runner.os == 'Linux (Clang-20 rtsan)'
+        run: |
+
+
       - name: Install JUCE's Linux Deps
         if: runner.os == 'Linux'
         # Thanks to McMartin & co https://forum.juce.com/t/list-of-juce-dependencies-under-linux/15121/44
         run: |
-          sudo apt-get update -yqq
-          sudo apt install -yqq libasound2-dev libx11-dev libxinerama-dev libxext-dev libfreetype6-dev libwebkit2gtk-4.1-dev libglu1-mesa-dev xvfb ninja-build libcurl4-openssl-dev ${{ matrix.packages }}
+          apt-get update -yqq
+          apt install -yqq libasound2-dev libx11-dev libxinerama-dev libxext-dev libfreetype6-dev libwebkit2gtk-4.1-dev libglu1-mesa-dev xvfb ninja-build libcurl4-openssl-dev ${{ matrix.packages }}
 
           # Install clang-tools for benchmark runner if missing (clang-scan-deps lives here)
           if [[ "${{ matrix.name }}" == "Linux (Benchmarks)" ]]; then
-            sudo apt-get install -yqq clang-tools-18
+            apt-get install -yqq clang-tools-18
           fi
 
       - name: Install Ninja (Windows)

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,6 +28,9 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    # we only have a container if we are using the rtsan build
+    container:
+      image: ${{ matrix.image || '' }}
     strategy:
       fail-fast: false # show all errors for each platform (vs. cancel jobs on error)
       matrix:
@@ -43,6 +46,10 @@ jobs:
             os: ubuntu-latest
             extra-flags: -DCMAKE_C_COMPILER=clang-19 -DCMAKE_CXX_COMPILER=clang++-19 -G"Ninja Multi-Config" -DCMAKE_C_FLAGS="-fsanitize=address -fsanitize=undefined"  -DCMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=undefined"
             packages: clang-19 libclang-rt-19-dev clang-tools-19
+          - name: Linux (Clang-20 rtsan)
+            os: ubuntu-latest
+            extra-flags: -DCMAKE_C_COMPILER=clang-20 -DCMAKE_CXX_COMPILER=clang++-20 -G"Ninja Multi-Config" -DCMAKE_C_FLAGS="-fsanitize=realtime"  -DCMAKE_CXX_FLAGS="-fsanitize=realtime"
+            image: ghcr.io/guillaumeriousat/algogris-rtsan:latest
           - name: macOS
             os: macos-15
             extra-flags: -G"Ninja Multi-Config" -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"  -DCMAKE_C_FLAGS=" -fsanitize=address -fsanitize=undefined" -DCMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=undefined"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "configurePresets": [
+    {
+      "name": "rtsan",
+      "displayName": "rtsan",
+      "description": "build with rtsan (needs a special clang20)",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "-fsanitize=realtime",
+        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=realtime"
+      }
+    }
+  ]
+}

--- a/sg_DopplerSpatAlgorithm.cpp
+++ b/sg_DopplerSpatAlgorithm.cpp
@@ -93,7 +93,7 @@ void DopplerSpatAlgorithm::process(AudioConfig const & config,
                                    SpeakerAudioBuffer & speakersBuffer,
                                    juce::AudioBuffer<float> & /*stereoBuffer*/,
                                    SourcePeaks const & /*sourcePeaks*/,
-                                   [[maybe_unused]] SpeakersAudioConfig const * altSpeakerConfig)
+                                   [[maybe_unused]] SpeakersAudioConfig const * altSpeakerConfig) [[clang::nonblocking]]
 {
     ASSERT_AUDIO_THREAD;
     jassert(!altSpeakerConfig);

--- a/sg_DummySpatAlgorithm.hpp
+++ b/sg_DummySpatAlgorithm.hpp
@@ -55,7 +55,7 @@ public:
 #endif
                  juce::AudioBuffer<float> & /*stereoBuffer*/,
                  SourcePeaks const & /*sourcePeaks*/,
-                 SpeakersAudioConfig const * /*altSpeakerConfig*/) override
+                 SpeakersAudioConfig const * /*altSpeakerConfig*/) [[clang::nonblocking]] override
     {
     }
     [[nodiscard]] juce::Array<Triplet> getTriplets() const noexcept override { return juce::Array<Triplet>{}; }

--- a/sg_HrtfSpatAlgorithm.cpp
+++ b/sg_HrtfSpatAlgorithm.cpp
@@ -184,7 +184,7 @@ void HrtfSpatAlgorithm::process(AudioConfig const & config,
 #endif
                                 juce::AudioBuffer<float> & stereoBuffer,
                                 SourcePeaks const & sourcePeaks,
-                                [[maybe_unused]] SpeakersAudioConfig const * altSpeakerConfig)
+                                [[maybe_unused]] SpeakersAudioConfig const * altSpeakerConfig) [[clang::nonblocking]]
 {
     ASSERT_AUDIO_THREAD;
     jassert(!altSpeakerConfig);

--- a/sg_HrtfSpatAlgorithm.cpp
+++ b/sg_HrtfSpatAlgorithm.cpp
@@ -42,7 +42,6 @@
 #include <array>
 #include <cstddef>
 #include <memory>
-#include <vector>
 
 namespace gris
 {
@@ -187,7 +186,6 @@ void HrtfSpatAlgorithm::process(AudioConfig const & config,
                                 SourcePeaks const & sourcePeaks,
                                 [[maybe_unused]] SpeakersAudioConfig const * altSpeakerConfig) [[clang::nonblocking]]
 {
-    auto oh_no_memory_allocationsssss = std::vector<float>(255);
     ASSERT_AUDIO_THREAD;
     jassert(!altSpeakerConfig);
     jassert(stereoBuffer.getNumChannels() == 2);

--- a/sg_HrtfSpatAlgorithm.cpp
+++ b/sg_HrtfSpatAlgorithm.cpp
@@ -42,6 +42,7 @@
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <vector>
 
 namespace gris
 {
@@ -186,6 +187,7 @@ void HrtfSpatAlgorithm::process(AudioConfig const & config,
                                 SourcePeaks const & sourcePeaks,
                                 [[maybe_unused]] SpeakersAudioConfig const * altSpeakerConfig) [[clang::nonblocking]]
 {
+    auto oh_no_memory_allocationsssss = std::vector<float>(255);
     ASSERT_AUDIO_THREAD;
     jassert(!altSpeakerConfig);
     jassert(stereoBuffer.getNumChannels() == 2);

--- a/sg_HybridSpatAlgorithm.cpp
+++ b/sg_HybridSpatAlgorithm.cpp
@@ -63,7 +63,7 @@ void HybridSpatAlgorithm::process(AudioConfig const & config,
 #endif
                                   juce::AudioBuffer<float> & stereoBuffer,
                                   SourcePeaks const & sourcePeaks,
-                                  SpeakersAudioConfig const * altSpeakerConfig)
+                                  SpeakersAudioConfig const * altSpeakerConfig) [[clang::nonblocking]]
 {
 #if SG_USE_FORK_UNION && (SG_FU_METHOD == SG_FU_USE_ARRAY_OF_ATOMICS || SG_FU_METHOD == SG_FU_USE_BUFFER_PER_THREAD)
     mVbap->process(config, sourcesBuffer, speakersBuffer, forkUnionBuffer, stereoBuffer, sourcePeaks, altSpeakerConfig);

--- a/sg_MbapSpatAlgorithm.cpp
+++ b/sg_MbapSpatAlgorithm.cpp
@@ -109,7 +109,7 @@ void MbapSpatAlgorithm::process(AudioConfig const & config,
 #endif
                                 [[maybe_unused]] juce::AudioBuffer<float> & stereoBuffer,
                                 SourcePeaks const & sourcePeaks,
-                                SpeakersAudioConfig const * altSpeakerConfig)
+                                SpeakersAudioConfig const * altSpeakerConfig) [[clang::nonblocking]]
 {
     ASSERT_AUDIO_THREAD;
 

--- a/sg_StereoSpatAlgorithm.cpp
+++ b/sg_StereoSpatAlgorithm.cpp
@@ -90,7 +90,7 @@ void StereoSpatAlgorithm::process(AudioConfig const & config,
 #endif
                                   juce::AudioBuffer<float> & stereoBuffer,
                                   SourcePeaks const & sourcePeaks,
-                                  [[maybe_unused]] SpeakersAudioConfig const * altSpeakerConfig)
+                                  [[maybe_unused]] SpeakersAudioConfig const * altSpeakerConfig) [[clang::nonblocking]]
 {
     ASSERT_AUDIO_THREAD;
     jassert(!altSpeakerConfig);

--- a/sg_VbapSpatAlgorithm.cpp
+++ b/sg_VbapSpatAlgorithm.cpp
@@ -118,7 +118,7 @@ void VbapSpatAlgorithm::process(AudioConfig const & config,
 #endif
                                 juce::AudioBuffer<float> & /*stereoBuffer*/,
                                 SourcePeaks const & sourcePeaks,
-                                SpeakersAudioConfig const * altSpeakerConfig)
+                                SpeakersAudioConfig const * altSpeakerConfig) [[clang::nonblocking]]
 {
     ASSERT_AUDIO_THREAD;
 


### PR DESCRIPTION
This enables us to use `-fsanitize=realtime` in clang > 20 to detect potential real-time unsafe function call in the audio processing functions. 

From the small tests I've done, it seems we are good on that front right now.