### PR TITLE
 Deactivate benchmark CI job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -35,9 +35,9 @@ jobs:
       fail-fast: false # show all errors for each platform (vs. cancel jobs on error)
       matrix:
         include:
-          - name: Linux (Benchmarks)
-            os: [ benchmarks ]
-            extra-flags: -G"Ninja Multi-Config" -DCMAKE_C_FLAGS="-fsanitize=address -fsanitize=undefined"  -DCMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=undefined"
+          # - name: Linux (Benchmarks)
+          #   os: [ benchmarks ]
+          #   extra-flags: -G"Ninja Multi-Config" -DCMAKE_C_FLAGS="-fsanitize=address -fsanitize=undefined"  -DCMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=undefined"
           - name: Linux (GCC)
             os: ubuntu-latest
             extra-flags: -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -G"Ninja Multi-Config" -DCMAKE_C_FLAGS="-fsanitize=address -fsanitize=undefined"  -DCMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=undefined"
@@ -126,7 +126,7 @@ jobs:
           echo "================================"
 
       - name: Commit benchmark results to benchmarks branch (only for Linux for now)
-        if: matrix.name == 'Linux'
+        if: matrix.name == 'Linux (Benchmarks)'
         run: |
           # Set up git account
           git config --global user.email "ci-bot@example.com"

--- a/.github/workflows/build_spatgris.yml
+++ b/.github/workflows/build_spatgris.yml
@@ -207,7 +207,7 @@ jobs:
           submodules/AlgoGRIS/submodules/StructGRIS/submodules/JUCE/extras/Projucer/Builds/VisualStudio2022/x64/Release/App/Projucer.exe --resave SpatGRIS.jucer
 
       - name: Build SpatGRIS
-        run: msbuild Builds/VisualStudio2022/SpatGRIS_App.vcxproj -p:Configuration=Release -p:Platform=x64 -p:IncludePath=../../asiosdk_2.3.3_2019-06-14/common/
+        run: msbuild Builds/VisualStudio2022/SpatGRIS_App.vcxproj -p:Configuration=Release -p:Platform=x64 -p:IncludePath=../../ASIOSDK/common/
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_spatgris.yml
+++ b/.github/workflows/build_spatgris.yml
@@ -8,7 +8,7 @@ on:
     branches: ['*']
 
 env:
-  SPATGRIS_REF: dev-sat
+  SPATGRIS_REF: dev
 
 jobs:
   Build-Ubuntu-Latest:


### PR DESCRIPTION
The benchmark runs on a physical machine at the SAT to get consistent performances. This machine sometimes has trouble picking up jobs and someone from the SAT needs to figure it out and maybe log into it. I'm disabling this so that the CI jobs don't timeout after 10h if the machine starts not picking up jobs and the SAT doesn't have anyone available to fix it. 

This does three other little things :

- Tt fixes the ASIO driver path for the window's build of SpatGRIS in the CI
- It fixes a name matching bug with the benchmark task if we ever decide to reactivate it.
- It makes it so the build SpatGRIS step targets dev instead of dev-sat which is now outdated.