### PR TITLE
Replace pre-computed matrices with a linear lookup table in mbap (but bugfixed)

### DIFF
--- a/Implementations/sg_mbap.cpp
+++ b/Implementations/sg_mbap.cpp
@@ -60,7 +60,6 @@ float linearInterpolation(const MbapField & field,
                           float const speaker_z)
 {
     static constexpr auto H_SIZE = MBAP_SIZE_CONSTANT / 2.0f;
-    std::cout << "linearly interpolate" << "\n";
 
     auto sk_x = speaker_x * (H_SIZE) + H_SIZE;
     auto sk_y = speaker_y * (H_SIZE) + H_SIZE;

--- a/Implementations/sg_mbap.cpp
+++ b/Implementations/sg_mbap.cpp
@@ -2,9 +2,7 @@
  * Matrix-Based Amplitude Panning framework.
  *
  * MBAP (Matrix-Based Amplitude Panning) is a framework
- * to do 3-D sound spatialization. It uses a pre-computed
- * gain matrix to perform the spatialization of the sources very
- * efficiently.
+ * to do 3-D sound spatialization.
  *
  * author : Gaël Lane Lépine, 2022
  * based on lbap from Olivier Belanger
@@ -52,31 +50,34 @@ namespace gris
 {
 namespace
 {
-//==============================================================================
-/* Trilinear interpolation to retrieve the value at position (x, y, z) in a 3D matrix. */
-static float trilinearInterpolation(matrix_t const & matrix, float const x, float const y, float const z)
-{
-    jassert(x >= 0.0f && y >= 0.0f && z >= 0.0f);
-    auto const xi = static_cast<std::size_t>(x);
-    auto const yi = static_cast<std::size_t>(y);
-    auto const zi = static_cast<std::size_t>(z);
-    auto const xf = narrow<float>(x) - narrow<float>(xi);
-    auto const yf = narrow<float>(y) - narrow<float>(yi);
-    auto const zf = narrow<float>(z) - narrow<float>(zi);
-    auto const v1 = matrix[xi][yi][zi];
-    auto const v2 = matrix[xi + 1][yi][zi];
-    auto const v3 = matrix[xi][yi + 1][zi];
-    auto const v4 = matrix[xi + 1][yi + 1][zi];
-    auto const v5 = matrix[xi][yi][zi + 1];
-    auto const v6 = matrix[xi + 1][yi][zi + 1];
-    auto const v7 = matrix[xi][yi + 1][zi + 1];
-    auto const v8 = matrix[xi + 1][yi + 1][zi + 1];
 
-    // from
-    // https://www.scratchapixel.com/code.php?id=56&origin=/lessons/mathematics-physics-for-computer-graphics/interpolation
-    return (1 - xf) * (1 - yf) * (1 - zf) * v1 + xf * (1 - yf) * (1 - zf) * v2 + (1 - xf) * yf * (1 - zf) * v3
-           + xf * yf * (1 - zf) * v4 + (1 - xf) * (1 - yf) * zf * v5 + xf * (1 - yf) * zf * v6 + (1 - xf) * yf * zf * v7
-           + xf * yf * zf * v8;
+float linearInterpolation(const MbapField & field,
+                          float const source_x,
+                          float const source_y,
+                          float const source_z,
+                          float const speaker_x,
+                          float const speaker_y,
+                          float const speaker_z)
+{
+    static constexpr auto H_SIZE = MBAP_SIZE_CONSTANT / 2.0f;
+    std::cout << "linearly interpolate" << "\n";
+
+    auto sk_x = speaker_x * (H_SIZE) + H_SIZE;
+    auto sk_y = speaker_y * (H_SIZE) + H_SIZE;
+    auto sk_z = speaker_z * (H_SIZE) + H_SIZE;
+
+    double dist
+        = std::sqrt(std::pow(source_x - sk_x, 2.0) + std::pow(source_y - sk_y, 2.0) + std::pow(source_z - sk_z, 2.0));
+
+    dist = std::clamp(dist, 0.0, MAX_DISTANCE);
+
+    auto table_idx = dist / DISTANCE_INCREMENT;
+    auto table_idx_floor = static_cast<int>(table_idx);
+    auto table_idx_ceil = static_cast<int>(std::ceil(table_idx_floor));
+    auto fractional_part = table_idx - static_cast<float>(table_idx_floor);
+    auto val1 = field.distanceLookupTable[table_idx_floor];
+    auto val2 = field.distanceLookupTable[table_idx_ceil];
+    return val1 + fractional_part * (val2 - val1);
 }
 
 //==============================================================================
@@ -98,39 +99,26 @@ static MbapField initField(std::vector<Position> speakers)
 {
     MbapField field{};
 
-    field.amplitudeMatrix.reserve(speakers.size());
-    static constexpr matrix_t EMPTY_MATRIX{};
-    std::fill_n(std::back_inserter(field.amplitudeMatrix), speakers.size(), EMPTY_MATRIX);
     field.speakerPositions = std::move(speakers);
 
     return field;
 }
 
-//==============================================================================
-/* Pre-compute the 3 dimensional matrix of amplitude for the speakers. */
-static void computeMatrix(MbapField & field)
+/**
+ * instead of computing one matrix for every speaker, just compute a lookup table of all the domain of possible value
+ * and linear interpolate over that instead.
+ */
+static void computeLookup(MbapField & field)
 {
-    static auto constexpr H_SIZE = MBAP_MATRIX_SIZE / 2;
+    // This is the max value that is going to ever be looked up in this table so we need to generate the table for
+    // entries from 0.0 to MAX_DISTANCE.
 
-    for (size_t i{}; i < field.speakerPositions.size(); ++i) {
-        auto const px = field.speakerPositions[i].getCartesian().x * H_SIZE + H_SIZE;
-        auto const py = field.speakerPositions[i].getCartesian().y * H_SIZE + H_SIZE;
-        auto const pz = field.speakerPositions[i].getCartesian().z * H_SIZE + H_SIZE;
+    for (int i = 0; i < LOOKUP_SIZE; i++) {
+        float dist_val = i * (MAX_DISTANCE / static_cast<float>(LOOKUP_SIZE));
 
-        for (size_t x{}; x < MBAP_MATRIX_SIZE; ++x) {
-            for (size_t y{}; y < MBAP_MATRIX_SIZE; ++y) {
-                for (size_t z{}; z < MBAP_MATRIX_SIZE; ++z) {
-                    auto dist = std::sqrt(std::pow(narrow<float>(x) - px, 2.0f) + std::pow(narrow<float>(y) - py, 2.0f)
-                                          + std::pow(narrow<float>(z) - pz, 2.0f));
+        dist_val = std::pow(db_root_power_ratio, dist_val);
 
-                    dist = std::pow(std::pow(10.0f, 1.0f / 20), dist);          // root-power ratio
-                    field.amplitudeMatrix[i][x][y][z] = 1.0f / std::sqrt(dist); // inverse square law
-                }
-                field.amplitudeMatrix[i][x][y][MBAP_MATRIX_SIZE] = field.amplitudeMatrix[i][x][y][0];
-            }
-            field.amplitudeMatrix[i][x][MBAP_MATRIX_SIZE] = field.amplitudeMatrix[i][x][0];
-        }
-        field.amplitudeMatrix[i][MBAP_MATRIX_SIZE] = field.amplitudeMatrix[i][0];
+        field.distanceLookupTable[i] = 1.0f / std::sqrt(dist_val);
     }
 }
 
@@ -139,7 +127,7 @@ static void computeMatrix(MbapField & field)
 static MbapField createField(std::vector<Position> speakers)
 {
     auto result{ initField(std::move(speakers)) };
-    computeMatrix(result);
+    computeLookup(result);
     return result;
 }
 
@@ -147,8 +135,8 @@ static MbapField createField(std::vector<Position> speakers)
 /* Compute the gain of field of speakers, for the given position, and store the result in the `gains` array.*/
 static void computeGains(MbapField const & field, SourceData const & source, float * gains)
 {
-    static constexpr auto H_SIZE = MBAP_MATRIX_SIZE / 2.0f;
-    static constexpr auto SIZE_MINUS_ONE = MBAP_MATRIX_SIZE - 1.0f;
+    static constexpr auto H_SIZE = MBAP_SIZE_CONSTANT / 2.0f;
+    static constexpr auto SIZE_MINUS_ONE = MBAP_SIZE_CONSTANT - 1.0f;
 
     auto constexpr EXPONENT_MIN_IN{ 0.0f };
     auto constexpr EXPONENT_MAX_IN{ 1.0f };
@@ -172,8 +160,6 @@ static void computeGains(MbapField const & field, SourceData const & source, flo
     float distXYPlane{};
     float distZ{};
 
-    jassert(field.speakerPositions.size() == field.amplitudeMatrix.size());
-
     auto const finalElevSpanExponent{ ((sourceElevationSpan - EXPONENT_MIN_IN) * (EXPONENT_MAX_OUT - EXPONENT_MIN_OUT)
                                        / (EXPONENT_MAX_IN - EXPONENT_MIN_IN))
                                       + EXPONENT_MIN_OUT };
@@ -194,7 +180,13 @@ static void computeGains(MbapField const & field, SourceData const & source, flo
 
         distXYPlane = std::sqrt(squaredDistX + squaredDistY);
 
-        auto const gain{ trilinearInterpolation(field.amplitudeMatrix[i], x, y, z) };
+        auto const gain{ linearInterpolation(field,
+                                             x,
+                                             y,
+                                             z,
+                                             field.speakerPositions[i].getCartesian().x,
+                                             field.speakerPositions[i].getCartesian().y,
+                                             field.speakerPositions[i].getCartesian().z) };
 
         auto const gainNoSpan{ std::pow(gain, field.fieldExponent) };
         auto const gainFullElevSpan{ std::pow(gain, field.fieldExponent * distXYPlane) };
@@ -241,7 +233,6 @@ size_t MbapField::getNumSpeakers() const
 void MbapField::reset()
 {
     outputOrder.clear();
-    amplitudeMatrix.clear();
 }
 
 //==============================================================================

--- a/Implementations/sg_mbap.hpp
+++ b/Implementations/sg_mbap.hpp
@@ -1,18 +1,14 @@
 /*
  This file is part of SpatGRIS.
-
  Developers: Gaël Lane Lépine, Samuel Béland, Olivier Bélanger, Nicolas Masson
-
  SpatGRIS is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
-
  SpatGRIS is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
-
  You should have received a copy of the GNU General Public License
  along with SpatGRIS.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -21,9 +17,7 @@
  * Matrix-Based Amplitude Panning framework.
  *
  * MBAP (Matrix-Based Amplitude Panning) is a framework
- * to do 3-D sound spatialization. It uses a pre-computed
- * gain matrix to perform the spatialization of the sources very
- * efficiently.
+ * to do 3-D sound spatialization.
  *
  * author : Gaël Lane Lépine, 2022
  * based on lbap from Olivier Belanger
@@ -44,9 +38,20 @@ namespace gris
 {
 struct SpeakerData;
 
-static auto constexpr MBAP_MATRIX_SIZE = 64;
-using matrix_t
-    = std::array<std::array<std::array<float, MBAP_MATRIX_SIZE + 1>, MBAP_MATRIX_SIZE + 1>, MBAP_MATRIX_SIZE + 1>;
+// This used to be the size of a precomputed matrix. Now that we use a linear
+// lookup table, this is kept as a constant to keep gain factors equivalent to what they
+// used to be.
+static auto constexpr MBAP_SIZE_CONSTANT = 64;
+// Size of the distance -> gain factor table. 256 is enough to get < 0.01% error.
+auto constexpr LOOKUP_SIZE = 256;
+// Maximum distance a source can get from a speaker considering we clamp each position to MBAP_SIZE_CONSTANT -1
+static const double MAX_DISTANCE = std::ceil(std::sqrt(
+    std::pow(MBAP_SIZE_CONSTANT, 2.0) + std::pow(MBAP_SIZE_CONSTANT, 2.0) + std::pow(MBAP_SIZE_CONSTANT, 2.0)));
+
+// We need this to be a double to avoir precision problems.
+static double const DISTANCE_INCREMENT = MAX_DISTANCE / static_cast<float>(LOOKUP_SIZE - 1);
+
+static const float db_root_power_ratio = std::pow(10.0f, 1.0f / 20);
 
 struct MbapSpeaker {
     Position position{};
@@ -57,8 +62,10 @@ struct MbapSpeaker {
 struct MbapField {
     std::vector<output_patch_t> outputOrder; /**< Physical output order. */
     float fieldExponent;                     /**< Speaker gain exponent speakers. */
-    std::vector<matrix_t> amplitudeMatrix;   /**< Arrays of amplitude values [spk][x][y][z]. */
     std::vector<Position> speakerPositions;  /**< Array of speakers. */
+    // lookup table of the gain factor indexed by distance.
+    // minimum distance is 0 and max is MAX_DISTANCE.
+    std::array<float, LOOKUP_SIZE> distanceLookupTable;
     //==============================================================================
     [[nodiscard]] size_t getNumSpeakers() const;
     void reset();


### PR DESCRIPTION
This is the same as PR #34 but bugfixed

This replaces the pre-computed 3D gain matrices in the mbap algorithm with a small (512 samples) 1D lookup table of "distance from speaker to source" -> "gain".

I have benchmarked this to be about two times faster than the matrix approach while being more accurate. The old approach had relative errors from 1 to 10% while this approach has relative errors of less than 0.01%.

In an empiric perceptual test in the SAT's sound studio, it sounds about the same.

The biggest improvement that comes from this is that the lookup table is very fast to compute. Some operations that used to take several seconds with large speakers setups in SpatGRIS like deleting a speaker are now near instant.

In theory, since the lookup table is speaker setup independent, we could compute it only once but right now it is computed every time the algorithm is instantiated. I don't think this matters much since it takes a fraction of a second to compute it.